### PR TITLE
Fixed links to events types

### DIFF
--- a/src/examples/shared/example-sections/types-of-data/index.tsx
+++ b/src/examples/shared/example-sections/types-of-data/index.tsx
@@ -25,22 +25,22 @@ const eventSections: EventSection = {
 
   page: {
     description: "what web page are they on?",
-    docLink: getDocLink("track"),
+    docLink: getDocLink("page"),
   },
 
   identify: {
     description: "who is the customer?",
-    docLink: getDocLink("track"),
+    docLink: getDocLink("identify"),
   },
 
   group: {
     description: "what account or organization are they part of?",
-    docLink: getDocLink("track"),
+    docLink: getDocLink("group"),
   },
 
   screen: {
     description: "what app screen are they on?",
-    docLink: getDocLink("track"),
+    docLink: getDocLink("screen"),
   },
 
   alias: {


### PR DESCRIPTION
getDocLink was pointing to the wrong event type

## Background

getDocLink was pointing to the wrong event type

## Testing

Testing not required because just fixing incorrect links.

## Deployment Procedure

This page is currently autodeployed through GH pages once merged.

## Rollback Procedure

Revert this PR.
