### PR TITLE
Set runner to ubuntu-latest, remove caching steps in favor of built-in setup-node caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,26 +7,16 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: "14.x"
-
-      - name: Get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: 'yarn'
 
       - name: Installing Dependencies
         run: yarn install


### PR DESCRIPTION

## Background

Deployments are currently failing with the following message: `This request was automatically failed because there were no enabled runners online to process the request for more than 1 days.`.  This is due to Ubuntu 18.04 being deprecated/removed: https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

Additionally, I removed some of the yarn caching steps in favor of the built-in caching that `setup-node@v3` supports now. I've tested it out in another repo and it's super fast + simple to setup.

## Testing

Testing not required because this is a CI change.

## Deployment Procedure

This page is currently autodeployed through GH pages once merged.

## Rollback Procedure

Revert this PR.
